### PR TITLE
[debops.kmod] Use the kmodpy Python module to list loaded modules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Added
 - New DebOps roles:
 
   - :ref:`debops.ansible`: install Ansible on a Debian/Ubuntu host using
-    Ansible. The :ref:`debops.debops` role now uses the the new role to install
+    Ansible. The :ref:`debops.debops` role now uses the new role to install
     Ansible instead of doing it directly.
 
   - :ref:`debops.apt_mark`: set install state of APT packages (manual/auto) or

--- a/ansible/roles/debops.kmod/COPYRIGHT
+++ b/ansible/roles/debops.kmod/COPYRIGHT
@@ -1,6 +1,7 @@
 debops.kmod - Manage kernel modules using Ansible
 
 Copyright (C) 2018 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2015-2018 Robin Schneider <ypid@riseup.net>
 Copyright (C) 2018 DebOps Project https://debops.org/
 
 This Ansible role is part of DebOps.

--- a/ansible/roles/debops.kmod/defaults/main.yml
+++ b/ansible/roles/debops.kmod/defaults/main.yml
@@ -22,6 +22,23 @@ kmod__enabled: '{{ True
                    else False }}'
                                                                    # ]]]
                                                                    # ]]]
+# Installation, APT packages [[[
+# ------------------------------
+
+# .. envvar:: kmod__base_packages [[[
+#
+# List of APT packages to install. They are used by the role internally.
+kmod__base_packages:
+  - '{{ "python-kmodpy" if (kmod__enabled|bool) else [] }}'
+
+                                                                   # ]]]
+# .. envvar:: kmod__packages [[[
+#
+# List of additional APT packages to install.
+kmod__packages: []
+
+                                                                   # ]]]
+                                                                   # ]]]
 # Kernel module configuration [[[
 # -------------------------------
 

--- a/ansible/roles/debops.kmod/meta/main.yml
+++ b/ansible/roles/debops.kmod/meta/main.yml
@@ -7,7 +7,7 @@ dependencies:
 galaxy_info:
 
   company: 'DebOps'
-  author: 'Maciej Delmanowski'
+  author: 'Maciej Delmanowski, Robin Schneider'
   description: 'Manage kernel modules'
   license: 'GPL-3.0'
   min_ansible_version: '2.4.0'
@@ -26,5 +26,6 @@ galaxy_info:
         - buster
 
   galaxy_tags:
+    - system
     - kernel
     - linux

--- a/ansible/roles/debops.kmod/tasks/main.yml
+++ b/ansible/roles/debops.kmod/tasks/main.yml
@@ -5,12 +5,34 @@
     path: '/sbin/modprobe'
   register: kmod__register_modprobe
 
-- name: Get list of loaded kernel modules
-  shell: lsmod | tail --lines=+2 | awk '{print $1}'
-  register: kmod__register_modules
-  check_mode: False
-  changed_when: False
-  when: kmod__enabled|bool
+- name: Install required packages
+  package:
+    name: '{{ item }}'
+    state: 'present'
+  with_flattened:
+    - '{{ kmod__base_packages }}'
+    - '{{ kmod__packages }}'
+
+- name: Make sure that Ansible local facts directory exists
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save kmod local facts
+  template:
+    src: 'etc/ansible/facts.d/kmod.fact.j2'
+    dest: '/etc/ansible/facts.d/kmod.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  register: kmod__register_facts
+
+- name: Update Ansible facts if they were modified
+  action: setup
+  when: kmod__register_facts is changed
 
 - name: Configure kernel modules
   include_tasks: 'modprobe.yml'
@@ -36,23 +58,7 @@
   with_items: '{{ kmod__combined_load | parse_kv_items }}'
   when: kmod__enabled|bool and item.name|d() and item.state|d('present') not in [ 'absent', 'ignore' ]
 
-- name: Make sure that Ansible local facts directory exists
-  file:
-    path: '/etc/ansible/facts.d'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-
-- name: Save kmod local facts
-  template:
-    src: 'etc/ansible/facts.d/kmod.fact.j2'
-    dest: '/etc/ansible/facts.d/kmod.fact'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-  register: kmod__register_facts
-
-- name: Update Ansible facts if they were modified
+- name: Update Ansible facts if the list of load kernel modules might have changed
   action: setup
-  when: kmod__register_facts is changed
+  when: (kmod__register_module_config_delete is changed or
+         kmod__register_module_config_create is changed)

--- a/ansible/roles/debops.kmod/tasks/modprobe.yml
+++ b/ansible/roles/debops.kmod/tasks/modprobe.yml
@@ -24,7 +24,7 @@
   when: ((kmod__register_module_config_delete is changed or
           kmod__register_module_config_create is changed) and
          module.blacklist is not defined and
-         module.name in kmod__register_modules.stdout_lines and
+         module.name in ansible_local.kmod.modules and
          module.state|d('present') not in [ 'config' ])
 
 - name: Load kernel module if configuration changed

--- a/ansible/roles/debops.kmod/templates/etc/ansible/facts.d/kmod.fact.j2
+++ b/ansible/roles/debops.kmod/templates/etc/ansible/facts.d/kmod.fact.j2
@@ -4,25 +4,12 @@
 
 from __future__ import print_function
 from json import loads, dumps
-from sys import exit
-import subprocess
-import signal
-import os
+
+import kmodpy
 
 output = loads('''{{ {"configured": True,
                       "enabled": kmod__enabled|bool} | to_nice_json }}''')
 
-kernel_modules = []
-
-try:
-    with open(os.devnull, 'w') as devnull:
-        kernel_modules = subprocess.check_output(
-            ["/sbin/lsmod | tail -n +2 | awk '{print $1}'"],
-            shell=True, stderr=devnull).strip().split('\n')
-
-except subprocess.CalledProcessError:
-    pass
-
-output['modules'] = filter(None, kernel_modules)
+output['modules'] = [x[0] for x in kmodpy.Kmod().list()]
 
 print(dumps(output, sort_keys=True, indent=4))

--- a/docs/ansible/roles/debops.kmod/defaults-detailed.rst
+++ b/docs/ansible/roles/debops.kmod/defaults-detailed.rst
@@ -32,7 +32,7 @@ parameters:
 
 ``state``
   Optional. Specify the state of the kernel module and its configuration.
-  Multiple entries with the same ``name`` parameter are merged toghether in
+  Multiple entries with the same ``name`` parameter are merged together in
   order of appearance; the ``state`` parameter can affect how the entries are
   merged.
 
@@ -169,7 +169,7 @@ kmod__load
 ----------
 
 The ``kmod__*_load`` list variables can be used to specify which kernel modules
-shoud be loaded at boot time. The configuration is stored in the
+should be loaded at boot time. The configuration is stored in the
 :file:`/etc/modules-load.d/` directory. Each list entry is a YAML dictionary
 with specific parameters:
 
@@ -185,7 +185,7 @@ with specific parameters:
 
 ``state``
   Optional. Specify the state of the kernel module and its configuration.
-  Multiple entries with the same ``name`` parameter are merged toghether in
+  Multiple entries with the same ``name`` parameter are merged together in
   order of appearance; the ``state`` parameter can affect how the entries are
   merged.
 


### PR DESCRIPTION
Updates: https://github.com/debops/debops/pull/229