### PR TITLE
[debops.etckeeper] Rework Ansible facts Python script

### DIFF
--- a/ansible/roles/debops.etckeeper/COPYRIGHT
+++ b/ansible/roles/debops.etckeeper/COPYRIGHT
@@ -1,6 +1,6 @@
 debops.etckeeper - Put /etc under version control using etckeeper
 
-Copyright (C) 2016-2017 Robin Schneider <ypid@riseup.net>
+Copyright (C) 2016-2018 Robin Schneider <ypid@riseup.net>
 Copyright (C)      2018 Maciej Delmanowski <drybjed@gmail.com>
 Copyright (C) 2016-2018 DebOps https://debops.org/
 

--- a/ansible/roles/debops.etckeeper/meta/main.yml
+++ b/ansible/roles/debops.etckeeper/meta/main.yml
@@ -7,7 +7,7 @@ dependencies:
 galaxy_info:
 
   company: 'DebOps'
-  author: 'Robin Schneider'
+  author: 'Robin Schneider, Maciej Delmanowski'
   description: 'Put /etc under version control using etckeeper'
   license: 'GPL-3.0'
   min_ansible_version: '2.1.3'

--- a/ansible/roles/debops.etckeeper/templates/etc/ansible/facts.d/etckeeper.fact.j2
+++ b/ansible/roles/debops.etckeeper/templates/etc/ansible/facts.d/etckeeper.fact.j2
@@ -4,10 +4,14 @@
 
 from __future__ import print_function
 from json import loads, dumps
-from sys import exit
 import subprocess
-import signal
 import os
+
+
+try:
+    from subprocess import DEVNULL
+except ImportError:
+    DEVNULL = open(os.devnull, 'wb')
 
 
 def cmd_exists(cmd):
@@ -30,37 +34,24 @@ commit_msg = loads('''{{ etckeeper__commit_message_fact | to_json }}''')
 output['installed'] = cmd_exists('etckeeper')
 
 if output['enabled'] is True and output['installed'] is True:
-    try:
-        with open(os.devnull, 'w') as devnull:
-            etckeeper_unclean = subprocess.Popen(
-                ["/usr/bin/etckeeper unclean"],
-                shell=True, stderr=devnull)
-            etckeeper_run = etckeeper_unclean.communicate()
-            rc = etckeeper_unclean.returncode
+    etckeeper_unclean_rc = subprocess.call(
+        ['etckeeper', 'unclean'],
+        stdout=DEVNULL, stderr=DEVNULL)
 
-            if rc == 0:  # The /etc is unclean
-                try:
-                    etckeeper_commit = subprocess.Popen(
-                        ["/usr/bin/etckeeper commit '" +
-                         commit_msg + "'"],
-                        shell=True, stdout=devnull, stderr=devnull)
-                    etckeeper_run = etckeeper_commit.communicate()
-                    output['commit'] = True
-
-                except subprocess.CalledProcessError:
-                    pass
-
-    except subprocess.CalledProcessError:
-        pass
+    if etckeeper_unclean_rc == 0:  # The /etc is unclean
+        subprocess.call(
+            ['etckeeper', 'commit', commit_msg],
+            stdout=DEVNULL, stderr=DEVNULL)
+        output['commit'] = True
 
     if os.path.exists(config_file) and os.path.isfile(config_file):
         try:
-            with open(config_file, "r") as f:
+            with open(config_file, 'r') as f:
                 for line in f:
                     if not line.startswith('#') and '=' in line:
                         line = line.strip().split('=')
-                        output.update({str(line[0]).lower():
-                                       str(line[1]).strip('"')})
+                        output.update({line[0].lower():
+                                       line[1].strip('"')})
         except Exception:
             pass
 


### PR DESCRIPTION
* Never use `shell=True` if you don’t have to! It is a potential
  security issue. Before this commit, it would have been possible to
  execute arbitrary code as root using shell injection with
  `etckeeper__commit_message_fact`. DebOps Developers would not consider
  this a vulnerability because the Ansible Controller is trusted but
  still, why allow it?

* Don’t use `subprocess.Popen` when `subprocess.call` is enough.

* Don’t use full paths. It is expected that `etckeeper` is in `$PATH`.

* No unneeded imports.