### PR TITLE
let's configure ssl parameters globally

### DIFF
--- a/ansible/roles/debops.nginx/tasks/main.yml
+++ b/ansible/roles/debops.nginx/tasks/main.yml
@@ -156,7 +156,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  with_items: [ 'acme-challenge' ]
+  with_items: [ 'acme-challenge', 'ssl' ]
   when: (nginx__deploy_state in [ 'present' ])
   notify: [ 'Test nginx and reload' ]
 

--- a/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/sites-available/default.conf.j2
@@ -614,6 +614,7 @@ server {
         include snippets/acme-challenge.conf;
 
 {%     endif                                                    %}
+        include snippets/ssl.conf;
 {% endif                                                        %}
 {# ---- end of nginx_tpl_ssl ---- #}
 {{ print_shared_nginx_server_block() }}

--- a/ansible/roles/debops.nginx/templates/etc/nginx/snippets/ssl.conf.j2
+++ b/ansible/roles/debops.nginx/templates/etc/nginx/snippets/ssl.conf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+# Add global ssl config
+
+ssl_protocols             {{ nginx_default_tls_protocols | join(" ") }};
+ssl_prefer_server_ciphers on;
+ssl_ciphers               {{ nginx_ssl_ciphers[nginx_default_ssl_ciphers] }};
+ssl_dhparam               {{ nginx_ssl_dhparam }};
+ssl_ecdh_curve            {{ nginx_default_ssl_curve }};


### PR DESCRIPTION
https://github.com/debops/debops/issues/266#issuecomment-376119402

... you're right, it's probably the better way - even if I see no conflicting with non-ssl sites since there are ony changed default parameters and no actual ssl configuration.

But with snippets it's anyway clearer to find and understand. 